### PR TITLE
[chore] Update actions/cache to v4

### DIFF
--- a/.github/workflows/sql-extraction.yml
+++ b/.github/workflows/sql-extraction.yml
@@ -36,7 +36,7 @@ jobs:
         run: ./gradlew build
 
       - name: Upload build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: tools/sql_extraction/build/distributions/*

--- a/.github/workflows/sql-extraction.yml
+++ b/.github/workflows/sql-extraction.yml
@@ -23,7 +23,7 @@ jobs:
           java-version: 1.8
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-sql-extraction-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/vscode-automatic-query-fixer.yml
+++ b/.github/workflows/vscode-automatic-query-fixer.yml
@@ -74,3 +74,4 @@ jobs:
         uses: GabrielBB/xvfb-action@v1.2
         with:
           run: npm test
+          working-directory: tools/vscode_automatic_query_fixer

--- a/.github/workflows/vscode-automatic-query-fixer.yml
+++ b/.github/workflows/vscode-automatic-query-fixer.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 18.x
 
       - name: Cache node modules
         uses: actions/cache@v4

--- a/.github/workflows/vscode-automatic-query-fixer.yml
+++ b/.github/workflows/vscode-automatic-query-fixer.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 18.x
 
       - name: Cache node modules
         uses: actions/cache@v4

--- a/.github/workflows/vscode-automatic-query-fixer.yml
+++ b/.github/workflows/vscode-automatic-query-fixer.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 10.x
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -56,7 +56,7 @@ jobs:
           node-version: 10.x
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/vscode-sql-extraction.yml
+++ b/.github/workflows/vscode-sql-extraction.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 18.x
 
       - name: Cache node modules
         uses: actions/cache@v4
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 18.x
 
       - name: Cache node modules
         uses: actions/cache@v4

--- a/.github/workflows/vscode-sql-extraction.yml
+++ b/.github/workflows/vscode-sql-extraction.yml
@@ -74,3 +74,4 @@ jobs:
         uses: GabrielBB/xvfb-action@v1.2
         with:
           run: npm test
+          working-directory: tools/vscode_sql_extraction

--- a/.github/workflows/vscode-sql-extraction.yml
+++ b/.github/workflows/vscode-sql-extraction.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 10.x
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -56,7 +56,7 @@ jobs:
           node-version: 10.x
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
v2 is out of date and workflows will fail from Feb 2025. v4 is the latest version